### PR TITLE
Merchants alternative initial data loading

### DIFF
--- a/tests/load_merchants_test_data.py
+++ b/tests/load_merchants_test_data.py
@@ -30,7 +30,7 @@ class MongoSampleUser(MongoUser):
             'merch_id': self.faker.random_int(min=901000, max=901030),
             # using percentage weights to simulate the number of documents to insert for each group
             # Group 1 = 0.05%, Group 2 = 0.9% & Group 3 = 90.5%
-            'merch_id': self.faker.random_element(elements=OrderedDict([
+            'merch_id': faker.random_element(elements=OrderedDict([
                     (self.faker.random_int(min=10000, max=10100), 0.005), # Group 1
                     (self.faker.random_int(min=20000, max=20020), 0.09), # Group 2
                     (self.faker.random_int(min=30001, max=30002), 0.905) # Group 3


### PR DESCRIPTION
Added a new python script to generate n authorisation documents based on a logic that applies weights to the different merchant group IDs.
The script runs the insert across several processes as specified in the numberOfProcesses variable. To run the script you can use the following command in the terminal:
python3 tests/load_merchants_test_data_threaded.py 10000
Please note that 10000 argument specifies how many documents to generate and upload. If it is omitted, the default of 1.6 billion documents will be generated!