### PR TITLE
Added parallel processing of all merchant groups

### DIFF
--- a/resources/document_generator.py
+++ b/resources/document_generator.py
@@ -2,7 +2,6 @@ from typing import OrderedDict
 from faker import Faker
 
 class Authorisation:
-    
 
     def generate_new_weighted_authorisation_doc():
         faker = Faker()
@@ -20,6 +19,125 @@ class Authorisation:
                     (faker.random_int(min=20000, max=20020), 0.09), # Group 2
                     (faker.random_int(min=30001, max=30002), 0.905) # Group 3
                 ])),
+            'alliance_code': faker.lexify(text='????', letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+            'bank_name': faker.lexify(text='???? PLC.', letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+            'bank_country': faker.country(),
+            'posting_date': faker.date_time_between(start_date='-2y', end_date='-1y'),
+            'merchant_details': {
+                'external_merch_id': faker.random_int(min=100000, max=999999),
+                'custom_merch_id': faker.random_int(min=100000, max=999999),
+                'merch_type': faker.lexify(text='??????', letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+                'name': faker.company(),
+                'trade_name': faker.company(),
+                'msc_iso': faker.random_int(min=100000, max=1000000),
+                'partner_code': faker.lexify(text='???', letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ') + 
+                str(faker.random_int(min=10000, max=20000))
+            },
+            'agent_code': faker.random_int(min=10000, max=1000000),
+            'platform_code': faker.random_int(min=10000, max=1000000),
+            'instrument_details': {
+                'instrument_num': faker.random_int(min=10000, max=1000000),
+                'instrument_num_masked': faker.random_int(min=1000000000000000, max=9000000000000000),
+                'instrument_type_code': faker.lexify(text='???', letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+                'instrument_type_subcode': faker.lexify(text='???', letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ')
+            },
+            'auth_details': {
+                'auth_code': faker.lexify(text='?????????', letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+                'auth_date': faker.date_time_between(start_date='-2y', end_date='-1y'),
+                'auth_exp': faker.date_time_between(start_date='-2y', end_date='-1y'),
+                'auth_flag': 'AA',
+                'auth_id': faker.bothify(text='####?##???#######?####?#', letters='abcdefghijklmnopqrstuvwxyz'),
+                'auth_ref_id': faker.random_int(min=10000, max=1000000),
+                'auth_seq': faker.random_int(min=1, max=10),
+                'auth_time': faker.time(),
+                'auth_method': faker.random_element(elements=OrderedDict([
+                    ('ABC', 0.4),
+                    ('123', 0.3),
+                    ('XYZ', 0.3)
+                ])),
+                'auth_method_code': faker.random_int(min=1021, max=2131),
+                'auth_platform_code': faker.random_int(min=1021, max=2131)
+            },
+            'acquirer_details': {
+                'merch_id': faker.random_int(min=901000, max=901030),
+                'resp_code': faker.random_int(min=9001, max=9999),
+                'resp_code_desc': faker.sentence(nb_words=6, variable_nb_words=True),
+                'terminal_id': faker.random_int(min=301000, max=301030),
+                'acquired_id': faker.random_int(min=401000, max=401030),
+                'bin': faker.lexify(text='????', letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+                'token': faker.bothify(text='####?##???#######?####?#', letters='abcdefghijklmnopqrstuvwxyz')
+            },
+            'account_details': {
+                'account_type': faker.random_element(elements=OrderedDict([
+                    ('Credit', 0.45),
+                    ('Debit', 0.45),
+                    ('Chequing', 0.05)
+                ])),
+                'account_type_code': faker.random_element(elements=OrderedDict([
+                    ('CR1213', 0.45),
+                    ('DB1212', 0.45),
+                    ('CQ1213', 0.05)
+                ])),
+                'account_update_service_flag': faker.lexify(text='??', letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ')
+            },
+            'card_details': {
+                'card_classification': faker.lexify(text='??????'),
+                'card_curr_code': faker.random_element(elements=OrderedDict([
+                    ('EUR', 0.45),
+                    ('GBP', 0.45),
+                    ('USD', 0.05)
+                ])),
+                'card_holder_name': faker.name(),
+                'card_service_type_code': faker.lexify(text='????', letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+                'card_usage_code': faker.lexify(text='????', letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+                'card_verification': faker.lexify(text='??????'),
+                'card_verification_code': faker.lexify(text='????', letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+                'cardholder_email': faker.free_email(),
+                'card_present_indicator': faker.random_element(elements=OrderedDict([
+                    ('N', 0.25),
+                    ('Y', 0.75)
+                ]))
+            },
+            'transaction_details': {
+                'source_code': faker.lexify(text='?', letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+                'location': faker.lexify(text='???', letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+                'type': faker.lexify(text='??????????', letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+                'transmission_date': faker.date_time_between(start_date='-2y', end_date='-1y'),
+                'transmission_time': faker.time(),
+                'merchant_tran_ref': faker.random_int(min=10000, max=1000000),
+                'purchase_amount': faker.pyfloat(right_digits=2, positive=True, min_value=1, max_value=1000),
+                'cashback_amount': faker.pyfloat(right_digits=2, min_value=0, max_value=10),
+                'tip': faker.pybool(),
+                'tip_amount': faker.pyfloat(right_digits=2, min_value=0, max_value=10)
+            },
+            'store_id': faker.random_int(min=901010, max=901020),
+            'order_id': faker.random_int(min=901010, max=901020),
+            'terminal_details': {
+                'terminal_id': faker.random_int(min=1201010, max=3402020),
+                'ip_address': faker.ipv4_public(),
+                'terminal_curr_code': faker.random_element(elements=OrderedDict([
+                    ('EUR', 0.45),
+                    ('GBP', 0.45),
+                    ('USD', 0.05)
+                ])),
+                'terminal_batch_num': faker.random_int(min=1201010, max=3402020),
+                'pos_entry': faker.lexify(text='??', letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+                'pos_capability': faker.lexify(text='???', letters='abcdefghijklmnopqrstuvwxyz')
+            }
+        }
+        return document
+
+    def generate_new_grouped_authorisation_doc(group_range_min, group_range_max):
+        faker = Faker()
+
+        """
+        Generate an authorisation document using weights to switch between the 3 groups of merchants
+        """
+        document = {
+            'auth_id': faker.uuid4(),
+            'merch_id': faker.random_int(min=901000, max=901030),
+            # using defined number of requests in script for each group range
+            'merch_id': faker.random_int(min=group_range_min, max=group_range_max),
             'alliance_code': faker.lexify(text='????', letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
             'bank_name': faker.lexify(text='???? PLC.', letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
             'bank_country': faker.country(),

--- a/tests/load_grouped_merchants_test_data_threaded.py
+++ b/tests/load_grouped_merchants_test_data_threaded.py
@@ -94,13 +94,13 @@ def run(group, process_id, docs_to_insert, logFileName):
     print(insert_rate_message)
 
 if __name__ == '__main__':
-    if len(sys.argv) > 2:
+    if len(sys.argv) > 3:
         groupOneDocs = int(sys.argv[1])
         groupTwoDocs = int(sys.argv[2])
         groupThreeDocs = int(sys.argv[3])
         totalDocs = groupOneDocs + groupTwoDocs + groupThreeDocs
     else:
-        print("Please specify the number of documents to load for each group")
+        print("Please specify the number of documents to load for each group. This script expects 3 number of documents to be provided as arguments.")
         exit()
 
     for i in range(2):

--- a/tests/load_grouped_merchants_test_data_threaded.py
+++ b/tests/load_grouped_merchants_test_data_threaded.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+import os, sys
+sys.path.append('resources/')
+currentdir = os.path.dirname(os.path.realpath(__file__))
+parentdir = os.path.dirname(currentdir)
+sys.path.append(parentdir)
+from multiprocessing import Process
+from pymongo import MongoClient
+import datetime
+from settings import DB_NAME, CLUSTER_URL
+import document_generator
+
+AUTH_COL = "authorisations"
+
+# Number of processes to launch & number of documents to insert
+numberOfProcessesGroup1 = 10
+numberOfProcessesGroup2 = 10
+numberOfProcessesGroup3 = 10
+totalNumberOfProcesses = 0
+processesList = []
+
+groupOneDocs = 7300000
+groupTwoDocs = 146000000
+groupThreeDocs = 1460000000
+totalDocs = 0
+
+def run(group, process_id, docs_to_insert, logFileName):
+    print("Group 1 connecting to Atlas Cluster at: " + CLUSTER_URL)
+    client = MongoClient(CLUSTER_URL)
+    db = client[DB_NAME]
+    coll = db[AUTH_COL]
+
+    # log the beginning of processing
+    start_time = datetime.datetime.now()
+    start_message = group + " - Process: " + str(process_id) + " started inserting " + str(docs_to_insert) + " documents at " + str(start_time)
+    
+    with open(logFileName, "a") as f:
+        f.write(start_message + "\n")
+    
+    print(start_message)
+
+    #generate min and max group with defaults for group 1
+    min_group = 10000
+    max_group = 10100 
+
+    if(group == "Group 2"):
+        min_group = 20000
+        max_group = 20020
+    if(group == "Group 3"):
+        min_group = 30001
+        max_group = 30002
+
+    # execute the insertion of the documents
+    for i in range(docs_to_insert):        
+        doc = document_generator.Authorisation.generate_new_grouped_authorisation_doc(min_group, max_group)
+
+        coll.insert_one(doc)
+        i += 1
+
+        printStr = (str(datetime.datetime.now()) + 
+                    ": " + group + " Group 1 - Process: " + 
+                    str(process_id) + 
+                    " generated authorisation document with auth_id: " + 
+                    str(doc["auth_id"]) + 
+                    " and merchant ID: " + 
+                    str(doc["merch_id"]) + "\n")
+        with open(logFileName, "a") as f:
+            f.write(printStr)
+
+    end_time = datetime.datetime.now()
+    end_message = (group + " - Process: " + 
+                    str(process_id) + 
+                    " completed inserting " + 
+                    str(docs_to_insert) + 
+                    " documents at " + str(end_time))
+    duration = end_time - start_time
+    duration_message = (group + " - Process: " + 
+                        str(process_id) + 
+                        " took " + 
+                        str((duration.total_seconds()) / 60) + 
+                        " minutes to complete.")
+    insert_rate_message = (group + " - The insert rate was: " 
+                            + str(round(docs_to_insert / duration.total_seconds())) + 
+                            " documents per second.")
+
+    # log results
+    with open(logFileName, "a") as f:
+        f.write(end_message + "\n")
+        f.write(duration_message + "\n")
+        f.write(insert_rate_message + "\n")
+
+    print(end_message)
+    print(duration_message)
+    print(insert_rate_message)
+
+if __name__ == '__main__':
+    if len(sys.argv) > 2:
+        groupOneDocs = int(sys.argv[1])
+        groupTwoDocs = int(sys.argv[2])
+        groupThreeDocs = int(sys.argv[3])
+        totalDocs = groupOneDocs + groupTwoDocs + groupThreeDocs
+    else:
+        print("Please specify the number of documents to load for each group")
+        exit()
+
+    for i in range(2):
+        if i == 0:
+            if (groupOneDocs <= numberOfProcessesGroup1):
+                numberOfProcessesGroup1 = groupOneDocs
+        if i == 1:
+            if (groupTwoDocs <= numberOfProcessesGroup2):
+                numberOfProcessesGroup2 = groupTwoDocs
+        if i == 2:
+            if (groupThreeDocs <= numberOfProcessesGroup3):
+                numberOfProcessesGroup3 = groupThreeDocs
+
+    filename = "runlogs/Merchants_Inserts_Log_" + str(totalDocs) + ".log"
+    print(filename)
+    if os.path.exists(filename):
+        os.remove(filename)
+        
+    totalNumberOfProcesses = numberOfProcessesGroup1 + numberOfProcessesGroup2 + numberOfProcessesGroup3
+    printStr = ("Launching " + str(totalNumberOfProcesses) + 
+                " processes to insert " +
+                str(totalDocs) +
+                " documents...\n")
+        
+    with open(filename, "a") as f:
+        f.write(printStr)
+
+    print(printStr)
+
+    # create the process list and add processes for each group
+    for i in range(numberOfProcessesGroup1):
+        process = Process(target=run, args=("Group 1", i, round(groupOneDocs / numberOfProcessesGroup1), filename))
+        processesList.append(process)
+
+    for i in range(numberOfProcessesGroup2):
+        process = Process(target=run, args=("Group 2", i, round(groupTwoDocs / numberOfProcessesGroup2), filename))
+        processesList.append(process)
+
+    for i in range(numberOfProcessesGroup3):
+        process = Process(target=run, args=("Group 3", i, round(groupThreeDocs / numberOfProcessesGroup3), filename))
+        processesList.append(process)
+
+    # launch processes
+    start_processing_time = datetime.datetime.now()
+    start_processing_message = (str(totalNumberOfProcesses) +
+                                " processes started processing " +
+                                str(totalDocs) + 
+                                " documents at " + 
+                                str(start_processing_time))
+    print(start_processing_message)
+    with open(filename, "a") as f:
+        f.write(start_processing_message + "\n")
+
+    for process in processesList:
+        process.start()
+
+    # wait for processes to complete
+    for process in processesList:
+        process.join()
+
+    end_processing_time = datetime.datetime.now()
+    end_processing_message = (str(totalNumberOfProcesses) + 
+                " processes completed at " +
+                str(end_processing_time))
+    print(end_processing_message)
+    with open(filename, "a") as f:
+        f.write(end_processing_message + "\n")
+
+    processing_duration = end_processing_time - start_processing_time
+    processing_duration_message = ("Processes took " + 
+                        str((processing_duration.total_seconds()) / 60) + 
+                        " minutes to complete.")
+    processing_insert_rate_message = ("The combined insert rate was: " 
+                            + str(round(totalDocs / processing_duration.total_seconds())) + 
+                            " documents per second.")
+
+    # log full results
+    with open(filename, "a") as f:
+        f.write(processing_duration_message + "\n")
+        f.write(processing_insert_rate_message + "\n\n")
+
+    with open(filename, "r") as f:
+        print(f.read())


### PR DESCRIPTION
Added a new file to load data simultaneously for all 3 merchant groups for an exact number of documents.
Processes for each merchant group are added to a process list and are all ran simultaneously. 
The run, it requires 3 arguments that provide the number of documents to be loaded for each group. If an argument is missing the script won't run.

`python3 tests/load_grouped_merchants_test_data_threaded.py 100 10000 1000000`